### PR TITLE
Correcciones segun reglas de negocio.

### DIFF
--- a/src/main/java/sic/controller/ClienteController.java
+++ b/src/main/java/sic/controller/ClienteController.java
@@ -1,6 +1,8 @@
 package sic.controller;
 
 import java.util.List;
+import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,6 +17,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import sic.modelo.BusquedaClienteCriteria;
 import sic.modelo.Cliente;
+import sic.modelo.Localidad;
+import sic.modelo.Pais;
+import sic.modelo.Provincia;
 import sic.service.IClienteService;
 import sic.service.IEmpresaService;
 import sic.service.ILocalidadService;
@@ -100,10 +105,10 @@ public class ClienteController {
        return clienteService.getClientePorId(cliente.getId_Cliente());
     }
     
-    @PutMapping("/clientes/predeterminado")
+    @PutMapping("/clientes/predeterminado/{idCliente}")
     @ResponseStatus(HttpStatus.OK)
-    public Cliente setClientePredeterminado(@RequestBody Cliente cliente) {
-       clienteService.setClientePredeterminado(cliente);
-       return clienteService.getClientePorId(cliente.getId_Cliente());
+    public Cliente setClientePredeterminado(@PathVariable long idCliente) {
+       clienteService.setClientePredeterminado(clienteService.getClientePorId(idCliente));
+       return clienteService.getClientePorId(idCliente);
     }
 }

--- a/src/main/java/sic/controller/ClienteController.java
+++ b/src/main/java/sic/controller/ClienteController.java
@@ -1,8 +1,6 @@
 package sic.controller;
 
 import java.util.List;
-import java.util.ResourceBundle;
-import javax.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -17,9 +15,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import sic.modelo.BusquedaClienteCriteria;
 import sic.modelo.Cliente;
-import sic.modelo.Localidad;
-import sic.modelo.Pais;
-import sic.modelo.Provincia;
 import sic.service.IClienteService;
 import sic.service.IEmpresaService;
 import sic.service.ILocalidadService;
@@ -105,7 +100,7 @@ public class ClienteController {
        return clienteService.getClientePorId(cliente.getId_Cliente());
     }
     
-    @PutMapping("/clientes/predeterminado/{idCliente}")
+    @PutMapping("/clientes/{idCliente}/predeterminado/")
     @ResponseStatus(HttpStatus.OK)
     public Cliente setClientePredeterminado(@PathVariable long idCliente) {
        clienteService.setClientePredeterminado(clienteService.getClientePorId(idCliente));

--- a/src/main/java/sic/controller/ProductoController.java
+++ b/src/main/java/sic/controller/ProductoController.java
@@ -1,6 +1,5 @@
 package sic.controller;
 
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;

--- a/src/main/java/sic/controller/ProductoController.java
+++ b/src/main/java/sic/controller/ProductoController.java
@@ -197,15 +197,10 @@ public class ProductoController {
                                                       @RequestParam(value = "idRubro", required = false) Long idRubro,
                                                       @RequestParam(value = "idProveedor", required = false) Long idProveedor,
                                                       @RequestBody(required = false) PreciosProducto preciosProducto) {
-        List<Producto> productos = new ArrayList<>();
-        for(long i : idProducto) {
-            productos.add(productoService.getProductoPorId(i));
-        }       
-        productoService.modificarMultiplesProductos(productos,
+        return productoService.modificarMultiplesProductos(idProducto,
                                                    (preciosProducto!=null), preciosProducto,
                                                    (idMedida!=null), medidaService.getMedidaPorId(idMedida),
                                                    (idRubro!=null), rubroService.getRubroPorId(idRubro),
-                                                   (idProveedor!=null), proveedorService.getProveedorPorId(idProveedor));
-        return productos;    
+                                                   (idProveedor!=null), proveedorService.getProveedorPorId(idProveedor));   
     }
 }

--- a/src/main/java/sic/modelo/Usuario.java
+++ b/src/main/java/sic/modelo/Usuario.java
@@ -1,5 +1,6 @@
 package sic.modelo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -50,8 +51,10 @@ public class Usuario implements Serializable {
     private String nombre;
 
     @Column(nullable = false)
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String password;
 
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private boolean permisosAdministrador;
 
     private boolean eliminado;

--- a/src/main/java/sic/modelo/Usuario.java
+++ b/src/main/java/sic/modelo/Usuario.java
@@ -9,11 +9,8 @@ import javax.persistence.Id;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "usuario")
@@ -37,9 +34,6 @@ import lombok.NoArgsConstructor;
                     + "WHERE u.eliminado = false AND u.nombre = :nombre AND u.password = :password")
 })
 @Data
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
 @EqualsAndHashCode(of = {"nombre"})
 public class Usuario implements Serializable {
 

--- a/src/main/java/sic/service/IProductoService.java
+++ b/src/main/java/sic/service/IProductoService.java
@@ -44,6 +44,6 @@ public interface IProductoService {
 
     Producto guardar(Producto producto);
 
-    void modificarMultiplesProductos(List<Producto> productos, boolean checkPrecios, PreciosProducto preciosProducto, boolean checkMedida, Medida medida, boolean checkRubro, Rubro rubro, boolean checkProveedor, Proveedor proveedor);
+    List<Producto> modificarMultiplesProductos(long[] idProductos, boolean checkPrecios, PreciosProducto preciosProducto, boolean checkMedida, Medida medida, boolean checkRubro, Rubro rubro, boolean checkProveedor, Proveedor proveedor);
 
 }

--- a/src/main/java/sic/service/impl/CajaServiceImpl.java
+++ b/src/main/java/sic/service/impl/CajaServiceImpl.java
@@ -87,8 +87,7 @@ public class CajaServiceImpl implements ICajaService {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                     .getString("mensaje_caja_anterior_abierta"));
         }
-        int comparacion = Validator.compararFechas(ultimaCaja.getFechaApertura() , caja.getFechaApertura());
-        if (comparacion <= 0) {
+        if (Validator.compararFechas(ultimaCaja.getFechaApertura(), caja.getFechaApertura()) <= 0) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                     .getString("mensaje_fecha_apertura_no_valida"));
         }
@@ -198,7 +197,7 @@ public class CajaServiceImpl implements ICajaService {
                     .getString("mensaje_usuario_no_existente"));
         }
         //Fecha
-        if (criteria.isBuscaPorFecha() == true & (criteria.getFechaDesde() == null | criteria.getFechaHasta() == null)) {
+        if (criteria.isBuscaPorFecha() == true && (criteria.getFechaDesde() == null || criteria.getFechaHasta() == null)) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                     .getString("mensaje_caja_fechas_invalidas"));
         }

--- a/src/main/java/sic/service/impl/CajaServiceImpl.java
+++ b/src/main/java/sic/service/impl/CajaServiceImpl.java
@@ -88,7 +88,7 @@ public class CajaServiceImpl implements ICajaService {
                     .getString("mensaje_caja_anterior_abierta"));
         }
         int comparacion = Validator.compararFechas(ultimaCaja.getFechaApertura() , caja.getFechaApertura());
-        if(comparacion < 0 || comparacion == 0) {
+        if (comparacion <= 0) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                     .getString("mensaje_fecha_apertura_no_valida"));
         }
@@ -120,7 +120,8 @@ public class CajaServiceImpl implements ICajaService {
     public void eliminar(Long idCaja) {
         Caja caja = this.getCajaPorId(idCaja);
         if (caja == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_caja_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_caja_no_existente"));
         }
         caja.setEliminada(true);
         this.actualizar(caja);
@@ -135,7 +136,8 @@ public class CajaServiceImpl implements ICajaService {
     public Caja getCajaPorId(Long id) {
         Caja caja = cajaRepository.getCajaPorId(id);
         if (caja == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_caja_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_caja_no_existente"));
         }
         return caja;
     }
@@ -187,15 +189,18 @@ public class CajaServiceImpl implements ICajaService {
     public List<Caja> getCajasCriteria(BusquedaCajaCriteria criteria) {
         //Empresa
         if (criteria.getEmpresa() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_empresa_no_existente"));
         }
         //Usuario
         if(criteria.isBuscaPorUsuario() == true && criteria.getUsuario() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_usuario_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_usuario_no_existente"));
         }
         //Fecha
         if (criteria.isBuscaPorFecha() == true & (criteria.getFechaDesde() == null | criteria.getFechaHasta() == null)) {
-            throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes").getString("mensaje_caja_fechas_invalidas"));
+            throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_caja_fechas_invalidas"));
         }
         if (criteria.isBuscaPorFecha() == true) {
             Calendar cal = new GregorianCalendar();
@@ -211,7 +216,8 @@ public class CajaServiceImpl implements ICajaService {
             criteria.setFechaHasta(cal.getTime());
         }        
         if (criteria.getEmpresa() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_empresa_no_existente"));
         }
         
         return cajaRepository.getCajasCriteria(criteria);        

--- a/src/main/java/sic/service/impl/CajaServiceImpl.java
+++ b/src/main/java/sic/service/impl/CajaServiceImpl.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JasperExportManager;
 import net.sf.jasperreports.engine.JasperFillManager;
@@ -38,6 +39,7 @@ import sic.service.ServiceException;
 import sic.util.FormatterFechaHora;
 import sic.util.FormatterNumero;
 import sic.util.Utilidades;
+import sic.util.Validator;
 
 @Service
 public class CajaServiceImpl implements ICajaService {
@@ -79,6 +81,17 @@ public class CajaServiceImpl implements ICajaService {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                     .getString("mensaje_caja_usuario_vacio"));
         }
+        //Una Caja por dia
+        Caja ultimaCaja = this.getUltimaCaja(caja.getEmpresa().getId_Empresa());
+        if(ultimaCaja.getEstado() == EstadoCaja.ABIERTA) {
+            throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_caja_anterior_abierta"));
+        }
+        int comparacion = Validator.compararFechas(ultimaCaja.getFechaApertura() , caja.getFechaApertura());
+        if(comparacion < 0 || comparacion == 0) {
+            throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_fecha_apertura_no_valida"));
+        }
         //Duplicados        
         if (cajaRepository.getCajaPorIdYEmpresa(caja.getId_Caja(), caja.getEmpresa().getId_Empresa()) != null) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
@@ -106,6 +119,9 @@ public class CajaServiceImpl implements ICajaService {
     @Transactional
     public void eliminar(Long idCaja) {
         Caja caja = this.getCajaPorId(idCaja);
+        if (caja == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_caja_no_existente"));
+        }
         caja.setEliminada(true);
         this.actualizar(caja);
     }
@@ -117,7 +133,11 @@ public class CajaServiceImpl implements ICajaService {
     
     @Override
     public Caja getCajaPorId(Long id) {
-        return cajaRepository.getCajaPorId(id);
+        Caja caja = cajaRepository.getCajaPorId(id);
+        if (caja == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_caja_no_existente"));
+        }
+        return caja;
     }
 
     @Override
@@ -165,6 +185,15 @@ public class CajaServiceImpl implements ICajaService {
 
     @Override
     public List<Caja> getCajasCriteria(BusquedaCajaCriteria criteria) {
+        //Empresa
+        if (criteria.getEmpresa() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+        }
+        //Usuario
+        if(criteria.isBuscaPorUsuario() == true && criteria.getUsuario() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_usuario_no_existente"));
+        }
+        //Fecha
         if (criteria.isBuscaPorFecha() == true & (criteria.getFechaDesde() == null | criteria.getFechaHasta() == null)) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes").getString("mensaje_caja_fechas_invalidas"));
         }
@@ -181,6 +210,9 @@ public class CajaServiceImpl implements ICajaService {
             cal.set(Calendar.SECOND, 59);
             criteria.setFechaHasta(cal.getTime());
         }        
+        if (criteria.getEmpresa() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+        }
         
         return cajaRepository.getCajasCriteria(criteria);        
     }

--- a/src/main/java/sic/service/impl/ClienteServiceImpl.java
+++ b/src/main/java/sic/service/impl/ClienteServiceImpl.java
@@ -2,6 +2,7 @@ package sic.service.impl;
 
 import java.util.List;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -27,7 +28,11 @@ public class ClienteServiceImpl implements IClienteService {
     }
 
     @Override
-    public Cliente getClientePorId(Long id_Cliente) {        
+    public Cliente getClientePorId(Long id_Cliente) {    
+        Cliente cliente = clienteRepository.getClientePorId(id_Cliente);
+        if (cliente == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_cliente_no_existente"));
+        }
         return clienteRepository.getClientePorId(id_Cliente);                  
     }
 
@@ -76,7 +81,21 @@ public class ClienteServiceImpl implements IClienteService {
     }
 
     @Override
-    public List<Cliente> buscarClientes(BusquedaClienteCriteria criteria) {    
+    public List<Cliente> buscarClientes(BusquedaClienteCriteria criteria) {
+        //Empresa
+        if (criteria.getEmpresa() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+        }
+        //Pais, Provincia y Localidad
+        if (criteria.getPais() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaja_pais_no_existente"));
+        }
+        if (criteria.getProvincia() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_provincia_no_existente"));
+        }
+        if(criteria.getLocalidad() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_localidad_no_existente"));
+        }
         return clienteRepository.buscarClientes(criteria);
     }
 
@@ -155,6 +174,9 @@ public class ClienteServiceImpl implements IClienteService {
     @Transactional
     public void eliminar(Long idCliente) {
         Cliente cliente = this.getClientePorId(idCliente);
+        if (cliente == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_cliente_no_existente"));
+        }
         cliente.setEliminado(true);        
         clienteRepository.actualizar(cliente);                   
     }

--- a/src/main/java/sic/service/impl/ClienteServiceImpl.java
+++ b/src/main/java/sic/service/impl/ClienteServiceImpl.java
@@ -28,12 +28,13 @@ public class ClienteServiceImpl implements IClienteService {
     }
 
     @Override
-    public Cliente getClientePorId(Long id_Cliente) {    
-        Cliente cliente = clienteRepository.getClientePorId(id_Cliente);
+    public Cliente getClientePorId(Long idCliente) {    
+        Cliente cliente = clienteRepository.getClientePorId(idCliente);
         if (cliente == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_cliente_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_cliente_no_existente"));
         }
-        return clienteRepository.getClientePorId(id_Cliente);                  
+        return cliente;                  
     }
 
     @Override
@@ -84,17 +85,21 @@ public class ClienteServiceImpl implements IClienteService {
     public List<Cliente> buscarClientes(BusquedaClienteCriteria criteria) {
         //Empresa
         if (criteria.getEmpresa() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_empresa_no_existente"));
         }
         //Pais, Provincia y Localidad
         if (criteria.getPais() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaja_pais_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaja_pais_no_existente"));
         }
         if (criteria.getProvincia() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_provincia_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_provincia_no_existente"));
         }
         if(criteria.getLocalidad() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_localidad_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_localidad_no_existente"));
         }
         return clienteRepository.buscarClientes(criteria);
     }
@@ -180,7 +185,8 @@ public class ClienteServiceImpl implements IClienteService {
     public void eliminar(Long idCliente) {
         Cliente cliente = this.getClientePorId(idCliente);
         if (cliente == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_cliente_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_cliente_no_existente"));
         }
         cliente.setEliminado(true);        
         clienteRepository.actualizar(cliente);                   

--- a/src/main/java/sic/service/impl/ClienteServiceImpl.java
+++ b/src/main/java/sic/service/impl/ClienteServiceImpl.java
@@ -152,6 +152,11 @@ public class ClienteServiceImpl implements IClienteService {
                         .getString("mensaje_cliente_duplicado_razonSocial"));
             }
         }
+        //Predeterminado 
+        if(cliente.isPredeterminado() == this.getClientePredeterminado(cliente.getEmpresa()).isPredeterminado()) {
+            throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_formaDePago_predeterminada_existente"));
+        }
     }
 
     @Override

--- a/src/main/java/sic/service/impl/CondicionDeIVAServiceImpl.java
+++ b/src/main/java/sic/service/impl/CondicionDeIVAServiceImpl.java
@@ -2,6 +2,7 @@ package sic.service.impl;
 
 import java.util.List;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -54,6 +55,9 @@ public class CondicionDeIVAServiceImpl implements ICondicionIVAService {
     @Transactional
     public void eliminar(Long idCondicionIVA) {
         CondicionIVA condicionIVA = this.getCondicionIVAPorId(idCondicionIVA);
+        if (condicionIVA == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_CondicionIVA_no_existente"));
+        }
         condicionIVA.setEliminada(true);        
         condicionIVARepository.actualizar(condicionIVA);
     }

--- a/src/main/java/sic/service/impl/CondicionDeIVAServiceImpl.java
+++ b/src/main/java/sic/service/impl/CondicionDeIVAServiceImpl.java
@@ -56,7 +56,8 @@ public class CondicionDeIVAServiceImpl implements ICondicionIVAService {
     public void eliminar(Long idCondicionIVA) {
         CondicionIVA condicionIVA = this.getCondicionIVAPorId(idCondicionIVA);
         if (condicionIVA == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_CondicionIVA_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_CondicionIVA_no_existente"));
         }
         condicionIVA.setEliminada(true);        
         condicionIVARepository.actualizar(condicionIVA);

--- a/src/main/java/sic/service/impl/ConfiguracionDelSistemaServiceImpl.java
+++ b/src/main/java/sic/service/impl/ConfiguracionDelSistemaServiceImpl.java
@@ -26,7 +26,8 @@ public class ConfiguracionDelSistemaServiceImpl implements IConfiguracionDelSist
     public ConfiguracionDelSistema getConfiguracionDelSistemaPorId(long id_ConfiguracionDelSistema) {
         ConfiguracionDelSistema cds = configuracionRepository.getConfiguracionDelSistemaPorId(id_ConfiguracionDelSistema); 
         if (cds == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_cds_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_cds_no_existente"));
         }
         return cds;        
     }

--- a/src/main/java/sic/service/impl/ConfiguracionDelSistemaServiceImpl.java
+++ b/src/main/java/sic/service/impl/ConfiguracionDelSistemaServiceImpl.java
@@ -1,5 +1,7 @@
 package sic.service.impl;
 
+import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -21,8 +23,12 @@ public class ConfiguracionDelSistemaServiceImpl implements IConfiguracionDelSist
     }
 
     @Override
-    public ConfiguracionDelSistema getConfiguracionDelSistemaPorId(long id_ConfiguracionDelSistema) {        
-        return configuracionRepository.getConfiguracionDelSistemaPorId(id_ConfiguracionDelSistema);        
+    public ConfiguracionDelSistema getConfiguracionDelSistemaPorId(long id_ConfiguracionDelSistema) {
+        ConfiguracionDelSistema cds = configuracionRepository.getConfiguracionDelSistemaPorId(id_ConfiguracionDelSistema); 
+        if (cds == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_cds_no_existente"));
+        }
+        return cds;        
     }
 
     @Override

--- a/src/main/java/sic/service/impl/EmpresaServiceImpl.java
+++ b/src/main/java/sic/service/impl/EmpresaServiceImpl.java
@@ -44,7 +44,7 @@ public class EmpresaServiceImpl implements IEmpresaService {
     @Override
     public List<Empresa> getEmpresas() {
         return empresaRepository.getEmpresas();
-        }
+    }
 
     @Override
     public Empresa getEmpresaPorNombre(String nombre) {

--- a/src/main/java/sic/service/impl/EmpresaServiceImpl.java
+++ b/src/main/java/sic/service/impl/EmpresaServiceImpl.java
@@ -32,10 +32,11 @@ public class EmpresaServiceImpl implements IEmpresaService {
     }
     
     @Override
-    public Empresa getEmpresaPorId(Long id_Empresa){
-        Empresa empresa = empresaRepository.getEmpresaPorId(id_Empresa);
+    public Empresa getEmpresaPorId(Long idEmpresa){
+        Empresa empresa = empresaRepository.getEmpresaPorId(idEmpresa);
         if (empresa == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_empresa_no_existente"));
         }
         return empresa;
     }
@@ -135,7 +136,8 @@ public class EmpresaServiceImpl implements IEmpresaService {
     public void eliminar(Long idEmpresa) {
         Empresa empresa = this.getEmpresaPorId(idEmpresa);
         if (empresa == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_empresa_no_existente"));
         }
         empresa.setEliminada(true);
         empresaRepository.actualizar(empresa);

--- a/src/main/java/sic/service/impl/EmpresaServiceImpl.java
+++ b/src/main/java/sic/service/impl/EmpresaServiceImpl.java
@@ -2,6 +2,7 @@ package sic.service.impl;
 
 import java.util.List;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -32,13 +33,17 @@ public class EmpresaServiceImpl implements IEmpresaService {
     
     @Override
     public Empresa getEmpresaPorId(Long id_Empresa){
-        return empresaRepository.getEmpresaPorId(id_Empresa);
+        Empresa empresa = empresaRepository.getEmpresaPorId(id_Empresa);
+        if (empresa == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+        }
+        return empresa;
     }
 
     @Override
     public List<Empresa> getEmpresas() {
         return empresaRepository.getEmpresas();
-    }
+        }
 
     @Override
     public Empresa getEmpresaPorNombre(String nombre) {
@@ -129,6 +134,9 @@ public class EmpresaServiceImpl implements IEmpresaService {
     @Transactional
     public void eliminar(Long idEmpresa) {
         Empresa empresa = this.getEmpresaPorId(idEmpresa);
+        if (empresa == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+        }
         empresa.setEliminada(true);
         empresaRepository.actualizar(empresa);
     }

--- a/src/main/java/sic/service/impl/FacturaServiceImpl.java
+++ b/src/main/java/sic/service/impl/FacturaServiceImpl.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JasperExportManager;
 import net.sf.jasperreports.engine.JasperFillManager;
@@ -230,6 +231,10 @@ public class FacturaServiceImpl implements IFacturaService {
 
     @Override
     public List<FacturaCompra> buscarFacturaCompra(BusquedaFacturaCompraCriteria criteria) {
+        //Empresa
+        if (criteria.getEmpresa() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+        }
         //Fecha de Factura        
         if (criteria.isBuscaPorFecha() == true & (criteria.getFechaDesde() == null | criteria.getFechaHasta() == null)) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
@@ -258,6 +263,10 @@ public class FacturaServiceImpl implements IFacturaService {
 
     @Override
     public List<FacturaVenta> buscarFacturaVenta(BusquedaFacturaVentaCriteria criteria) {
+        //Empresa
+        if(criteria.getEmpresa() == null ) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+        }
         //Fecha de Factura        
         if (criteria.isBuscaPorFecha() == true & (criteria.getFechaDesde() == null | criteria.getFechaHasta() == null)) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")

--- a/src/main/java/sic/service/impl/FacturaServiceImpl.java
+++ b/src/main/java/sic/service/impl/FacturaServiceImpl.java
@@ -233,7 +233,8 @@ public class FacturaServiceImpl implements IFacturaService {
     public List<FacturaCompra> buscarFacturaCompra(BusquedaFacturaCompraCriteria criteria) {
         //Empresa
         if (criteria.getEmpresa() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_empresa_no_existente"));
         }
         //Fecha de Factura        
         if (criteria.isBuscaPorFecha() == true & (criteria.getFechaDesde() == null | criteria.getFechaHasta() == null)) {
@@ -265,10 +266,11 @@ public class FacturaServiceImpl implements IFacturaService {
     public List<FacturaVenta> buscarFacturaVenta(BusquedaFacturaVentaCriteria criteria) {
         //Empresa
         if(criteria.getEmpresa() == null ) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_empresa_no_existente"));
         }
         //Fecha de Factura        
-        if (criteria.isBuscaPorFecha() == true & (criteria.getFechaDesde() == null | criteria.getFechaHasta() == null)) {
+        if (criteria.isBuscaPorFecha() == true && (criteria.getFechaDesde() == null || criteria.getFechaHasta() == null)) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                     .getString("mensaje_factura_fechas_busqueda_invalidas"));
         }

--- a/src/main/java/sic/service/impl/FormaDePagoServiceImpl.java
+++ b/src/main/java/sic/service/impl/FormaDePagoServiceImpl.java
@@ -2,6 +2,7 @@ package sic.service.impl;
 
 import java.util.List;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -31,7 +32,11 @@ public class FormaDePagoServiceImpl implements IFormaDePagoService {
 
     @Override
     public FormaDePago getFormasDePagoPorId(long id) {
-        return formaDePagoRepository.getFormaDePagoPorId(id);
+        FormaDePago formaDePago = formaDePagoRepository.getFormaDePagoPorId(id);
+        if (formaDePago == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_formaDePago_no_existente"));
+        }
+        return formaDePago;
     }
 
     @Override
@@ -84,6 +89,9 @@ public class FormaDePagoServiceImpl implements IFormaDePagoService {
     @Transactional
     public void eliminar(long idFormaDePago) {
         FormaDePago formaDePago = this.getFormasDePagoPorId(idFormaDePago);
+        if (formaDePago == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_formaDePago_no_existente"));
+        }
         formaDePago.setEliminada(true);
         formaDePagoRepository.actualizar(formaDePago);
     }

--- a/src/main/java/sic/service/impl/FormaDePagoServiceImpl.java
+++ b/src/main/java/sic/service/impl/FormaDePagoServiceImpl.java
@@ -31,10 +31,11 @@ public class FormaDePagoServiceImpl implements IFormaDePagoService {
     }
 
     @Override
-    public FormaDePago getFormasDePagoPorId(long id) {
-        FormaDePago formaDePago = formaDePagoRepository.getFormaDePagoPorId(id);
+    public FormaDePago getFormasDePagoPorId(long idFormaDePago) {
+        FormaDePago formaDePago = formaDePagoRepository.getFormaDePagoPorId(idFormaDePago);
         if (formaDePago == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_formaDePago_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_formaDePago_no_existente"));
         }
         return formaDePago;
     }
@@ -95,7 +96,8 @@ public class FormaDePagoServiceImpl implements IFormaDePagoService {
     public void eliminar(long idFormaDePago) {
         FormaDePago formaDePago = this.getFormasDePagoPorId(idFormaDePago);
         if (formaDePago == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_formaDePago_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_formaDePago_no_existente"));
         }
         formaDePago.setEliminada(true);
         formaDePagoRepository.actualizar(formaDePago);

--- a/src/main/java/sic/service/impl/FormaDePagoServiceImpl.java
+++ b/src/main/java/sic/service/impl/FormaDePagoServiceImpl.java
@@ -74,6 +74,11 @@ public class FormaDePagoServiceImpl implements IFormaDePagoService {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                     .getString("mensaje_formaDePago_duplicado_nombre"));
         }
+        //Predeterminado 
+        if(formaDePago.isPredeterminado() == this.getFormaDePagoPredeterminada(formaDePago.getEmpresa()).isPredeterminado()) {
+            throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_formaDePago_predeterminada_existente"));
+        }
     }
 
     @Override

--- a/src/main/java/sic/service/impl/GastoServiceImpl.java
+++ b/src/main/java/sic/service/impl/GastoServiceImpl.java
@@ -25,10 +25,11 @@ public class GastoServiceImpl implements IGastoService {
     }
     
     @Override
-    public Gasto getGastoPorId(Long id) {
-        Gasto gasto = gastoRepository.getGastoPorId(id);
+    public Gasto getGastoPorId(Long idGasto) {
+        Gasto gasto = gastoRepository.getGastoPorId(idGasto);
         if (gasto == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_gasto_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_gasto_no_existente"));
         }
         return gasto;
     }
@@ -67,8 +68,8 @@ public class GastoServiceImpl implements IGastoService {
     }
 
     @Override
-    public List<Gasto> getGastosPorFecha(Long id_Empresa, Date desde, Date hasta) {
-        return gastoRepository.getGastosPorFecha(id_Empresa, desde, hasta);
+    public List<Gasto> getGastosPorFecha(Long idEmpresa, Date desde, Date hasta) {
+        return gastoRepository.getGastosPorFecha(idEmpresa, desde, hasta);
     }
 
     @Override
@@ -77,8 +78,8 @@ public class GastoServiceImpl implements IGastoService {
     }
 
     @Override
-    public List<Gasto> getGastosPorFechaYFormaDePago(Long id_Empresa, Long id_FormaDePago, Date desde, Date hasta) {
-        return gastoRepository.getGastosPorFechaYFormaDePago(id_Empresa, id_FormaDePago, desde, hasta);
+    public List<Gasto> getGastosPorFechaYFormaDePago(Long idEmpresa, Long idFormaDePago, Date desde, Date hasta) {
+        return gastoRepository.getGastosPorFechaYFormaDePago(idEmpresa, idFormaDePago, desde, hasta);
     }
 
     @Override
@@ -88,13 +89,13 @@ public class GastoServiceImpl implements IGastoService {
     }
 
     @Override
-    public long getUltimoNumeroDeCaja(long id_Empresa) {
-        return gastoRepository.getUltimoNumeroDeGasto(id_Empresa);
+    public long getUltimoNumeroDeCaja(long idEmpresa) {
+        return gastoRepository.getUltimoNumeroDeGasto(idEmpresa);
     }
 
     @Override
-    public long getUltimoNumeroDeGasto(long id_empresa) {
-        return gastoRepository.getUltimoNumeroDeGasto(id_empresa);
+    public long getUltimoNumeroDeGasto(long idEmpresa) {
+        return gastoRepository.getUltimoNumeroDeGasto(idEmpresa);
     }
 
 }

--- a/src/main/java/sic/service/impl/GastoServiceImpl.java
+++ b/src/main/java/sic/service/impl/GastoServiceImpl.java
@@ -4,6 +4,7 @@ import sic.service.IGastoService;
 import java.util.Date;
 import java.util.List;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -25,7 +26,11 @@ public class GastoServiceImpl implements IGastoService {
     
     @Override
     public Gasto getGastoPorId(Long id) {
-       return gastoRepository.getGastoPorId(id);
+        Gasto gasto = gastoRepository.getGastoPorId(id);
+        if (gasto == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_gasto_no_existente"));
+        }
+        return gasto;
     }
 
     @Override

--- a/src/main/java/sic/service/impl/LocalidadServiceImpl.java
+++ b/src/main/java/sic/service/impl/LocalidadServiceImpl.java
@@ -27,10 +27,11 @@ public class LocalidadServiceImpl implements ILocalidadService {
     }
 
     @Override
-    public Localidad getLocalidadPorId(Long id_Localidad) {
-        Localidad localidad = localidadRepository.getLocalidadPorId(id_Localidad);
+    public Localidad getLocalidadPorId(Long idLocalidad) {
+        Localidad localidad = localidadRepository.getLocalidadPorId(idLocalidad);
         if (localidad == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_localidad_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_localidad_no_existente"));
         }
         return localidad;
     }

--- a/src/main/java/sic/service/impl/LocalidadServiceImpl.java
+++ b/src/main/java/sic/service/impl/LocalidadServiceImpl.java
@@ -2,6 +2,7 @@ package sic.service.impl;
 
 import java.util.List;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -27,7 +28,11 @@ public class LocalidadServiceImpl implements ILocalidadService {
 
     @Override
     public Localidad getLocalidadPorId(Long id_Localidad) {
-        return localidadRepository.getLocalidadPorId(id_Localidad);
+        Localidad localidad = localidadRepository.getLocalidadPorId(id_Localidad);
+        if (localidad == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_localidad_no_existente"));
+        }
+        return localidad;
     }
     
     @Override

--- a/src/main/java/sic/service/impl/MedidaServiceImpl.java
+++ b/src/main/java/sic/service/impl/MedidaServiceImpl.java
@@ -27,10 +27,11 @@ public class MedidaServiceImpl implements IMedidaService {
     }
 
     @Override
-    public Medida getMedidaPorId(Long id_Medida) {
-        Medida medida = medidaRepository.getMedidaPorId(id_Medida);
+    public Medida getMedidaPorId(Long idMedida) {
+        Medida medida = medidaRepository.getMedidaPorId(idMedida);
         if (medida == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_medida_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_medida_no_existente"));
         }
         return medida;
     }
@@ -88,7 +89,8 @@ public class MedidaServiceImpl implements IMedidaService {
     public void eliminar(long idMedida) {
         Medida medida = this.getMedidaPorId(idMedida);
         if (medida == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_medida_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_medida_no_existente"));
         }
         medida.setEliminada(true);
         medidaRepository.actualizar(medida);

--- a/src/main/java/sic/service/impl/MedidaServiceImpl.java
+++ b/src/main/java/sic/service/impl/MedidaServiceImpl.java
@@ -2,6 +2,7 @@ package sic.service.impl;
 
 import java.util.List;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -27,7 +28,11 @@ public class MedidaServiceImpl implements IMedidaService {
 
     @Override
     public Medida getMedidaPorId(Long id_Medida) {
-        return medidaRepository.getMedidaPorId(id_Medida);
+        Medida medida = medidaRepository.getMedidaPorId(id_Medida);
+        if (medida == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_medida_no_existente"));
+        }
+        return medida;
     }
     
     @Override
@@ -82,6 +87,9 @@ public class MedidaServiceImpl implements IMedidaService {
     @Transactional
     public void eliminar(long idMedida) {
         Medida medida = this.getMedidaPorId(idMedida);
+        if (medida == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_medida_no_existente"));
+        }
         medida.setEliminada(true);
         medidaRepository.actualizar(medida);
     }

--- a/src/main/java/sic/service/impl/PagoServiceImpl.java
+++ b/src/main/java/sic/service/impl/PagoServiceImpl.java
@@ -35,10 +35,11 @@ public class PagoServiceImpl implements IPagoService {
     }
 
     @Override
-    public Pago getPagoPorId(long id_pago) {
-        Pago pago = this.pagoRepository.getPagoPorId(id_pago);
+    public Pago getPagoPorId(long idPago) {
+        Pago pago = this.pagoRepository.getPagoPorId(idPago);
         if (pago == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_pago_inexistente_eliminado"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_pago_inexistente_eliminado"));
         }
         return pago;
     }

--- a/src/main/java/sic/service/impl/PagoServiceImpl.java
+++ b/src/main/java/sic/service/impl/PagoServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -35,7 +36,11 @@ public class PagoServiceImpl implements IPagoService {
 
     @Override
     public Pago getPagoPorId(long id_pago) {
-        return this.pagoRepository.getPagoPorId(id_pago);
+        Pago pago = this.pagoRepository.getPagoPorId(id_pago);
+        if (pago == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_pago_inexistente_eliminado"));
+        }
+        return pago;
     }
     
     @Override

--- a/src/main/java/sic/service/impl/PaisServiceImpl.java
+++ b/src/main/java/sic/service/impl/PaisServiceImpl.java
@@ -2,6 +2,7 @@ package sic.service.impl;
 
 import java.util.List;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,11 @@ public class PaisServiceImpl implements IPaisService {
     
     @Override
     public Pais getPaisPorId(Long id_Pais) {
-        return paisRepository.getPaisPorId(id_Pais);
+        Pais pais = paisRepository.getPaisPorId(id_Pais);
+        if (pais == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaja_pais_no_existente"));
+        }
+        return pais;
     }
 
     @Override
@@ -64,6 +69,9 @@ public class PaisServiceImpl implements IPaisService {
     @Transactional
     public void eliminar(Long idPais) {
         Pais pais = this.getPaisPorId(idPais);
+        if (pais == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaja_pais_no_existente"));
+        }
         pais.setEliminado(true);
         paisRepository.actualizar(pais);
     }

--- a/src/main/java/sic/service/impl/PaisServiceImpl.java
+++ b/src/main/java/sic/service/impl/PaisServiceImpl.java
@@ -26,10 +26,11 @@ public class PaisServiceImpl implements IPaisService {
     }
     
     @Override
-    public Pais getPaisPorId(Long id_Pais) {
-        Pais pais = paisRepository.getPaisPorId(id_Pais);
+    public Pais getPaisPorId(Long idPais) {
+        Pais pais = paisRepository.getPaisPorId(idPais);
         if (pais == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaja_pais_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaja_pais_no_existente"));
         }
         return pais;
     }
@@ -70,7 +71,8 @@ public class PaisServiceImpl implements IPaisService {
     public void eliminar(Long idPais) {
         Pais pais = this.getPaisPorId(idPais);
         if (pais == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaja_pais_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaja_pais_no_existente"));
         }
         pais.setEliminado(true);
         paisRepository.actualizar(pais);

--- a/src/main/java/sic/service/impl/PedidoServiceImpl.java
+++ b/src/main/java/sic/service/impl/PedidoServiceImpl.java
@@ -46,10 +46,11 @@ public class PedidoServiceImpl implements IPedidoService {
     }
 
     @Override
-    public Pedido getPedidoPorId(Long id) {
-        Pedido pedido = this.pedidoRepository.getPedidoPorId(id);
+    public Pedido getPedidoPorId(Long idPedido) {
+        Pedido pedido = this.pedidoRepository.getPedidoPorId(idPedido);
         if (pedido == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_pedido_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_pedido_no_existente"));
         }
         return pedido;
     }
@@ -74,8 +75,10 @@ public class PedidoServiceImpl implements IPedidoService {
                     .getString("mensaje_pedido_usuario_vacio"));
         }
         //ValidarEstado
-        if(pedido.getEstado() != EstadoPedido.ABIERTO & pedido.getEstado() != EstadoPedido.ACTIVO & pedido.getEstado() != EstadoPedido.CERRADO) {
-            throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes").getString("mensaja_estado_no_valido"));
+        EstadoPedido estadoPedido = pedido.getEstado();
+        if(estadoPedido != EstadoPedido.ABIERTO & estadoPedido!= EstadoPedido.ACTIVO & estadoPedido != EstadoPedido.CERRADO) {
+            throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaja_estado_no_valido"));
         }
         if (operacion == TipoDeOperacion.ALTA) {
             //Duplicados       
@@ -176,7 +179,8 @@ public class PedidoServiceImpl implements IPedidoService {
         }
         //Empresa
         if (criteria.getEmpresa() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_empresa_no_existente"));
         }
         //Cliente
         if (criteria.isBuscaCliente() == true && criteria.getCliente() == null) {
@@ -209,7 +213,8 @@ public class PedidoServiceImpl implements IPedidoService {
     public boolean eliminar(long idPedido) {
         Pedido pedido = this.getPedidoPorId(idPedido);
         if (pedido == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_pedido_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_pedido_no_existente"));
         }
         if (pedido.getEstado() == EstadoPedido.ABIERTO) {
             pedido.setEliminado(true);

--- a/src/main/java/sic/service/impl/PedidoServiceImpl.java
+++ b/src/main/java/sic/service/impl/PedidoServiceImpl.java
@@ -74,9 +74,9 @@ public class PedidoServiceImpl implements IPedidoService {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                     .getString("mensaje_pedido_usuario_vacio"));
         }
-        //ValidarEstado
-        EstadoPedido estadoPedido = pedido.getEstado();
-        if(estadoPedido != EstadoPedido.ABIERTO & estadoPedido!= EstadoPedido.ACTIVO & estadoPedido != EstadoPedido.CERRADO) {
+        //Validar Estado
+        EstadoPedido estado = pedido.getEstado();
+        if ((estado != EstadoPedido.ABIERTO) && (estado != EstadoPedido.ACTIVO) && (estado != EstadoPedido.CERRADO)) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                     .getString("mensaja_estado_no_valido"));
         }

--- a/src/main/java/sic/service/impl/PedidoServiceImpl.java
+++ b/src/main/java/sic/service/impl/PedidoServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JasperFillManager;
 import net.sf.jasperreports.engine.JasperExportManager;
@@ -46,7 +47,11 @@ public class PedidoServiceImpl implements IPedidoService {
 
     @Override
     public Pedido getPedidoPorId(Long id) {
-        return this.pedidoRepository.getPedidoPorId(id);
+        Pedido pedido = this.pedidoRepository.getPedidoPorId(id);
+        if (pedido == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_pedido_no_existente"));
+        }
+        return pedido;
     }
     
     private void validarPedido(TipoDeOperacion operacion, Pedido pedido) {
@@ -67,6 +72,10 @@ public class PedidoServiceImpl implements IPedidoService {
         if (pedido.getUsuario() == null) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                     .getString("mensaje_pedido_usuario_vacio"));
+        }
+        //ValidarEstado
+        if(pedido.getEstado() != EstadoPedido.ABIERTO & pedido.getEstado() != EstadoPedido.ACTIVO & pedido.getEstado() != EstadoPedido.CERRADO) {
+            throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes").getString("mensaja_estado_no_valido"));
         }
         if (operacion == TipoDeOperacion.ALTA) {
             //Duplicados       
@@ -165,6 +174,10 @@ public class PedidoServiceImpl implements IPedidoService {
             cal.set(Calendar.SECOND, 59);
             criteria.setFechaHasta(cal.getTime());
         }
+        //Empresa
+        if (criteria.getEmpresa() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+        }
         //Cliente
         if (criteria.isBuscaCliente() == true && criteria.getCliente() == null) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
@@ -195,6 +208,9 @@ public class PedidoServiceImpl implements IPedidoService {
     @Transactional
     public boolean eliminar(long idPedido) {
         Pedido pedido = this.getPedidoPorId(idPedido);
+        if (pedido == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_pedido_no_existente"));
+        }
         if (pedido.getEstado() == EstadoPedido.ABIERTO) {
             pedido.setEliminado(true);
             pedidoRepository.actualizar(pedido);

--- a/src/main/java/sic/service/impl/ProductoServiceImpl.java
+++ b/src/main/java/sic/service/impl/ProductoServiceImpl.java
@@ -237,15 +237,16 @@ public class ProductoServiceImpl implements IProductoService {
             boolean checkPrecios, PreciosProducto preciosProducto,
             boolean checkMedida, Medida medida,
             boolean checkRubro, Rubro rubro,
-            boolean checkProveedor, Proveedor proveedor) {    
-        if(Validator.tieneDuplicados(idProducto)) {
+            boolean checkProveedor, Proveedor proveedor) {
+        
+        if (Validator.tieneDuplicados(idProducto)) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                         .getString("mensaje_ids_duplicados"));
         }
         List<Producto> productos = new ArrayList<>();
-        for(long i : idProducto) {
+        for (long i : idProducto) {
             productos.add(this.getProductoPorId(i));
-        }  
+        }        
         //Requeridos
         if (checkMedida == true && medida == null) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")

--- a/src/main/java/sic/service/impl/ProductoServiceImpl.java
+++ b/src/main/java/sic/service/impl/ProductoServiceImpl.java
@@ -108,8 +108,7 @@ public class ProductoServiceImpl implements IProductoService {
         }
         //Duplicados
         //Codigo
-        if (producto.getCodigo() != null) {
-            if (!producto.getCodigo().equals("")) {
+        if (!producto.getCodigo().equals("")) {
             Producto productoDuplicado = this.getProductoPorCodigo(producto.getCodigo(), producto.getEmpresa());
             if (operacion.equals(TipoDeOperacion.ACTUALIZACION)
                     && productoDuplicado != null
@@ -122,10 +121,7 @@ public class ProductoServiceImpl implements IProductoService {
                     && !producto.getCodigo().equals("")) {
                 throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                         .getString("mensaje_producto_duplicado_codigo"));
-                }
             }
-        } else {
-            producto.setCodigo("");
         }
         //Descripcion
         Producto productoDuplicado = this.getProductoPorDescripcion(producto.getDescripcion(), producto.getEmpresa());
@@ -145,7 +141,8 @@ public class ProductoServiceImpl implements IProductoService {
     public List<Producto> buscarProductos(BusquedaProductoCriteria criteria) {
         //Empresa
         if (criteria.getEmpresa() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_empresa_no_existente"));
         }
         //Rubro
         if (criteria.isBuscarPorRubro() == true && criteria.getRubro() == null) {
@@ -163,6 +160,9 @@ public class ProductoServiceImpl implements IProductoService {
     @Override
     @Transactional
     public Producto guardar(Producto producto) {
+        if (producto.getCodigo() == null) {
+            producto.setCodigo("");
+        }
         this.validarOperacion(TipoDeOperacion.ALTA, producto);
         producto = productoRepository.guardar(producto);
         LOGGER.warn("El Producto " + producto + " se guardó correctamente.");
@@ -218,7 +218,8 @@ public class ProductoServiceImpl implements IProductoService {
         for (Long i : idProducto) {
             Producto producto = this.getProductoPorId(i);
             if (producto == null) {
-                throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_producto_no_existente"));
+                throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                        .getString("mensaje_producto_no_existente"));
             }
             producto.setEliminado(true);
             productos.add(producto);
@@ -287,10 +288,11 @@ public class ProductoServiceImpl implements IProductoService {
     }
 
     @Override
-    public Producto getProductoPorId(long id_Producto) {
-        Producto producto = productoRepository.getProductoPorId(id_Producto);
+    public Producto getProductoPorId(long idProducto) {
+        Producto producto = productoRepository.getProductoPorId(idProducto);
         if (producto == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_producto_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_producto_no_existente"));
         }
         return producto;
     }

--- a/src/main/java/sic/service/impl/ProductoServiceImpl.java
+++ b/src/main/java/sic/service/impl/ProductoServiceImpl.java
@@ -214,6 +214,10 @@ public class ProductoServiceImpl implements IProductoService {
     @Override
     @Transactional
     public void eliminarMultiplesProductos(long[] idProducto) {
+        if(Validator.tieneDuplicados(idProducto)) {
+            throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
+                        .getString("mensaje_ids_duplicados"));
+        }
         List<Producto> productos = new ArrayList<>();
         for (Long i : idProducto) {
             Producto producto = this.getProductoPorId(i);
@@ -229,12 +233,19 @@ public class ProductoServiceImpl implements IProductoService {
 
     @Override
     @Transactional
-    public void modificarMultiplesProductos(List<Producto> productos,
+    public List<Producto> modificarMultiplesProductos(long[] idProducto,
             boolean checkPrecios, PreciosProducto preciosProducto,
             boolean checkMedida, Medida medida,
             boolean checkRubro, Rubro rubro,
-            boolean checkProveedor, Proveedor proveedor) {
-
+            boolean checkProveedor, Proveedor proveedor) {    
+        if(Validator.tieneDuplicados(idProducto)) {
+            throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
+                        .getString("mensaje_ids_duplicados"));
+        }
+        List<Producto> productos = new ArrayList<>();
+        for(long i : idProducto) {
+            productos.add(this.getProductoPorId(i));
+        }  
         //Requeridos
         if (checkMedida == true && medida == null) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
@@ -285,6 +296,7 @@ public class ProductoServiceImpl implements IProductoService {
             }
         }
         productoRepository.actualizarMultiplesProductos(productos);
+        return productos;
     }
 
     @Override

--- a/src/main/java/sic/service/impl/ProductoServiceImpl.java
+++ b/src/main/java/sic/service/impl/ProductoServiceImpl.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JasperExportManager;
 import net.sf.jasperreports.engine.JasperFillManager;
@@ -107,7 +108,8 @@ public class ProductoServiceImpl implements IProductoService {
         }
         //Duplicados
         //Codigo
-        if (!producto.getCodigo().equals("")) {
+        if (producto.getCodigo() != null) {
+            if (!producto.getCodigo().equals("")) {
             Producto productoDuplicado = this.getProductoPorCodigo(producto.getCodigo(), producto.getEmpresa());
             if (operacion.equals(TipoDeOperacion.ACTUALIZACION)
                     && productoDuplicado != null
@@ -120,7 +122,10 @@ public class ProductoServiceImpl implements IProductoService {
                     && !producto.getCodigo().equals("")) {
                 throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                         .getString("mensaje_producto_duplicado_codigo"));
+                }
             }
+        } else {
+            producto.setCodigo("");
         }
         //Descripcion
         Producto productoDuplicado = this.getProductoPorDescripcion(producto.getDescripcion(), producto.getEmpresa());
@@ -138,6 +143,10 @@ public class ProductoServiceImpl implements IProductoService {
 
     @Override
     public List<Producto> buscarProductos(BusquedaProductoCriteria criteria) {
+        //Empresa
+        if (criteria.getEmpresa() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+        }
         //Rubro
         if (criteria.isBuscarPorRubro() == true && criteria.getRubro() == null) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
@@ -208,6 +217,9 @@ public class ProductoServiceImpl implements IProductoService {
         List<Producto> productos = new ArrayList<>();
         for (Long i : idProducto) {
             Producto producto = this.getProductoPorId(i);
+            if (producto == null) {
+                throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_producto_no_existente"));
+            }
             producto.setEliminado(true);
             productos.add(producto);
         }
@@ -276,7 +288,11 @@ public class ProductoServiceImpl implements IProductoService {
 
     @Override
     public Producto getProductoPorId(long id_Producto) {
-        return productoRepository.getProductoPorId(id_Producto);
+        Producto producto = productoRepository.getProductoPorId(id_Producto);
+        if (producto == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_producto_no_existente"));
+        }
+        return producto;
     }
 
     @Override

--- a/src/main/java/sic/service/impl/ProveedorServiceImpl.java
+++ b/src/main/java/sic/service/impl/ProveedorServiceImpl.java
@@ -28,10 +28,11 @@ public class ProveedorServiceImpl implements IProveedorService {
     }
 
     @Override
-    public Proveedor getProveedorPorId(Long id_Proveedor){
-        Proveedor proveedor = proveedorRepository.getProveedorPorId(id_Proveedor);
+    public Proveedor getProveedorPorId(Long idProvedor){
+        Proveedor proveedor = proveedorRepository.getProveedorPorId(idProvedor);
         if (proveedor == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_proveedor_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_proveedor_no_existente"));
         }
         return proveedor;
     }
@@ -45,17 +46,21 @@ public class ProveedorServiceImpl implements IProveedorService {
     public List<Proveedor> buscarProveedores(BusquedaProveedorCriteria criteria) {
         //Empresa
         if (criteria.getEmpresa() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_empresa_no_existente"));
         }
         //Pais, Provincia y Localidad
         if (criteria.getPais() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaja_pais_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaja_pais_no_existente"));
         }
         if (criteria.getProvincia() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_provincia_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_provincia_no_existente"));
         }
         if(criteria.getLocalidad() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_localidad_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_localidad_no_existente"));
         }
         return proveedorRepository.buscarProveedores(criteria);
     }
@@ -100,8 +105,7 @@ public class ProveedorServiceImpl implements IProveedorService {
         }
         //Duplicados
         //Codigo
-        if (proveedor.getCodigo() != null) {
-            if (!proveedor.getCodigo().equals("")) {
+        if (!proveedor.getCodigo().equals("")) {
             Proveedor proveedorDuplicado = this.getProveedorPorCodigo(proveedor.getCodigo(), proveedor.getEmpresa());
             if (operacion.equals(TipoDeOperacion.ACTUALIZACION)
                     && proveedorDuplicado != null
@@ -114,10 +118,7 @@ public class ProveedorServiceImpl implements IProveedorService {
                     && !proveedor.getCodigo().equals("")) {
                 throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                         .getString("mensaje_proveedor_duplicado_codigo"));
-                }
             }
-        } else {
-            proveedor.setCodigo("");
         }
         //ID Fiscal
         if (!proveedor.getId_Fiscal().equals("")) {
@@ -152,6 +153,9 @@ public class ProveedorServiceImpl implements IProveedorService {
     @Override
     @Transactional
     public Proveedor guardar(Proveedor proveedor) {
+        if(proveedor.getCodigo() == null) {
+            proveedor.setCodigo("");
+        }
         this.validarOperacion(TipoDeOperacion.ALTA, proveedor);
         proveedor = proveedorRepository.guardar(proveedor);
         LOGGER.warn("El Proveedor " + proveedor + " se guardó correctamente.");
@@ -170,7 +174,8 @@ public class ProveedorServiceImpl implements IProveedorService {
     public void eliminar(long idProveedor) {
         Proveedor proveedor = this.getProveedorPorId(idProveedor);
         if (proveedor == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_proveedor_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_proveedor_no_existente"));
         }
         proveedor.setEliminado(true);
         proveedorRepository.actualizar(proveedor);

--- a/src/main/java/sic/service/impl/ProveedorServiceImpl.java
+++ b/src/main/java/sic/service/impl/ProveedorServiceImpl.java
@@ -3,6 +3,7 @@ package sic.service.impl;
 import sic.modelo.BusquedaProveedorCriteria;
 import java.util.List;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -28,7 +29,11 @@ public class ProveedorServiceImpl implements IProveedorService {
 
     @Override
     public Proveedor getProveedorPorId(Long id_Proveedor){
-        return proveedorRepository.getProveedorPorId(id_Proveedor);
+        Proveedor proveedor = proveedorRepository.getProveedorPorId(id_Proveedor);
+        if (proveedor == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_proveedor_no_existente"));
+        }
+        return proveedor;
     }
     
     @Override
@@ -38,6 +43,20 @@ public class ProveedorServiceImpl implements IProveedorService {
 
     @Override
     public List<Proveedor> buscarProveedores(BusquedaProveedorCriteria criteria) {
+        //Empresa
+        if (criteria.getEmpresa() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+        }
+        //Pais, Provincia y Localidad
+        if (criteria.getPais() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaja_pais_no_existente"));
+        }
+        if (criteria.getProvincia() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_provincia_no_existente"));
+        }
+        if(criteria.getLocalidad() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_localidad_no_existente"));
+        }
         return proveedorRepository.buscarProveedores(criteria);
     }
 
@@ -81,7 +100,8 @@ public class ProveedorServiceImpl implements IProveedorService {
         }
         //Duplicados
         //Codigo
-        if (!proveedor.getCodigo().equals("")) {
+        if (proveedor.getCodigo() != null) {
+            if (!proveedor.getCodigo().equals("")) {
             Proveedor proveedorDuplicado = this.getProveedorPorCodigo(proveedor.getCodigo(), proveedor.getEmpresa());
             if (operacion.equals(TipoDeOperacion.ACTUALIZACION)
                     && proveedorDuplicado != null
@@ -94,7 +114,10 @@ public class ProveedorServiceImpl implements IProveedorService {
                     && !proveedor.getCodigo().equals("")) {
                 throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                         .getString("mensaje_proveedor_duplicado_codigo"));
+                }
             }
+        } else {
+            proveedor.setCodigo("");
         }
         //ID Fiscal
         if (!proveedor.getId_Fiscal().equals("")) {
@@ -146,6 +169,9 @@ public class ProveedorServiceImpl implements IProveedorService {
     @Transactional
     public void eliminar(long idProveedor) {
         Proveedor proveedor = this.getProveedorPorId(idProveedor);
+        if (proveedor == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_proveedor_no_existente"));
+        }
         proveedor.setEliminado(true);
         proveedorRepository.actualizar(proveedor);
     }

--- a/src/main/java/sic/service/impl/ProvinciaServiceImpl.java
+++ b/src/main/java/sic/service/impl/ProvinciaServiceImpl.java
@@ -27,10 +27,11 @@ public class ProvinciaServiceImpl implements IProvinciaService {
     }
     
     @Override
-    public Provincia getProvinciaPorId(Long id_Provincia) {
-        Provincia provincia = provinciaRepository.getProvinciaPorId(id_Provincia);
+    public Provincia getProvinciaPorId(Long idProvincia) {
+        Provincia provincia = provinciaRepository.getProvinciaPorId(idProvincia);
         if (provincia == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_provincia_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_provincia_no_existente"));
         }
         return provincia;
     }
@@ -75,7 +76,8 @@ public class ProvinciaServiceImpl implements IProvinciaService {
     public void eliminar(long idProvincia) {
         Provincia provincia = this.getProvinciaPorId(idProvincia);
         if (provincia == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_provincia_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_provincia_no_existente"));
         }
         provincia.setEliminada(true);
         provinciaRepository.actualizar(provincia);

--- a/src/main/java/sic/service/impl/ProvinciaServiceImpl.java
+++ b/src/main/java/sic/service/impl/ProvinciaServiceImpl.java
@@ -2,6 +2,7 @@ package sic.service.impl;
 
 import java.util.List;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -27,7 +28,11 @@ public class ProvinciaServiceImpl implements IProvinciaService {
     
     @Override
     public Provincia getProvinciaPorId(Long id_Provincia) {
-        return provinciaRepository.getProvinciaPorId(id_Provincia);
+        Provincia provincia = provinciaRepository.getProvinciaPorId(id_Provincia);
+        if (provincia == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_provincia_no_existente"));
+        }
+        return provincia;
     }
 
     @Override
@@ -69,6 +74,9 @@ public class ProvinciaServiceImpl implements IProvinciaService {
     @Transactional
     public void eliminar(long idProvincia) {
         Provincia provincia = this.getProvinciaPorId(idProvincia);
+        if (provincia == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_provincia_no_existente"));
+        }
         provincia.setEliminada(true);
         provinciaRepository.actualizar(provincia);
     }

--- a/src/main/java/sic/service/impl/RubroServiceImpl.java
+++ b/src/main/java/sic/service/impl/RubroServiceImpl.java
@@ -30,7 +30,8 @@ public class RubroServiceImpl implements IRubroService {
     public Rubro getRubroPorId(Long idRubro){
         Rubro rubro = rubroRepository.getRubroPorId(idRubro);
         if (rubro == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_pedido_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_pedido_no_existente"));
         }
         return rubro;
     }
@@ -87,7 +88,8 @@ public class RubroServiceImpl implements IRubroService {
     public void eliminar(long idRubro) {
         Rubro rubro = this.getRubroPorId(idRubro);
         if (rubro == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_pedido_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_pedido_no_existente"));
         }
         rubro.setEliminado(true);
         rubroRepository.actualizar(rubro);

--- a/src/main/java/sic/service/impl/RubroServiceImpl.java
+++ b/src/main/java/sic/service/impl/RubroServiceImpl.java
@@ -2,6 +2,7 @@ package sic.service.impl;
 
 import java.util.List;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -27,7 +28,11 @@ public class RubroServiceImpl implements IRubroService {
     
     @Override
     public Rubro getRubroPorId(Long idRubro){
-        return rubroRepository.getRubroPorId(idRubro);
+        Rubro rubro = rubroRepository.getRubroPorId(idRubro);
+        if (rubro == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_pedido_no_existente"));
+        }
+        return rubro;
     }
 
     @Override
@@ -81,6 +86,9 @@ public class RubroServiceImpl implements IRubroService {
     @Transactional
     public void eliminar(long idRubro) {
         Rubro rubro = this.getRubroPorId(idRubro);
+        if (rubro == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_pedido_no_existente"));
+        }
         rubro.setEliminado(true);
         rubroRepository.actualizar(rubro);
     }

--- a/src/main/java/sic/service/impl/TransportistaServiceImpl.java
+++ b/src/main/java/sic/service/impl/TransportistaServiceImpl.java
@@ -3,6 +3,7 @@ package sic.service.impl;
 import sic.modelo.BusquedaTransportistaCriteria;
 import java.util.List;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -28,7 +29,11 @@ public class TransportistaServiceImpl implements ITransportistaService {
     
     @Override
     public Transportista getTransportistaPorId(long id_Transportista) {
-        return transportistaRepository.getTransportistaPorId(id_Transportista);
+        Transportista transportista = transportistaRepository.getTransportistaPorId(id_Transportista);
+        if (transportista == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_transportista_no_existente"));
+        }
+        return transportista;
     }
 
     @Override
@@ -38,6 +43,20 @@ public class TransportistaServiceImpl implements ITransportistaService {
 
     @Override
     public List<Transportista> buscarTransportistas(BusquedaTransportistaCriteria criteria) {
+        //Empresa
+        if (criteria.getEmpresa() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+        }
+        //Pais, Provincia y Localidad
+        if (criteria.getPais() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaja_pais_no_existente"));
+        }
+        if (criteria.getProvincia() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_provincia_no_existente"));
+        }
+        if(criteria.getLocalidad() == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_localidad_no_existente"));
+        }
         return transportistaRepository.busquedaPersonalizada(criteria);
     }
 
@@ -95,6 +114,9 @@ public class TransportistaServiceImpl implements ITransportistaService {
     @Transactional
     public void eliminar(long idTransportista) {
         Transportista transportista = this.getTransportistaPorId(idTransportista);
+        if (transportista == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_transportista_no_existente"));
+        }
         transportista.setEliminado(true);
         transportistaRepository.actualizar(transportista);
     }

--- a/src/main/java/sic/service/impl/TransportistaServiceImpl.java
+++ b/src/main/java/sic/service/impl/TransportistaServiceImpl.java
@@ -28,10 +28,11 @@ public class TransportistaServiceImpl implements ITransportistaService {
     }
     
     @Override
-    public Transportista getTransportistaPorId(long id_Transportista) {
-        Transportista transportista = transportistaRepository.getTransportistaPorId(id_Transportista);
+    public Transportista getTransportistaPorId(long idTransportista) {
+        Transportista transportista = transportistaRepository.getTransportistaPorId(idTransportista);
         if (transportista == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_transportista_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_transportista_no_existente"));
         }
         return transportista;
     }
@@ -45,17 +46,21 @@ public class TransportistaServiceImpl implements ITransportistaService {
     public List<Transportista> buscarTransportistas(BusquedaTransportistaCriteria criteria) {
         //Empresa
         if (criteria.getEmpresa() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_empresa_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_empresa_no_existente"));
         }
         //Pais, Provincia y Localidad
         if (criteria.getPais() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaja_pais_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaja_pais_no_existente"));
         }
         if (criteria.getProvincia() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_provincia_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_provincia_no_existente"));
         }
         if(criteria.getLocalidad() == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_localidad_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_localidad_no_existente"));
         }
         return transportistaRepository.busquedaPersonalizada(criteria);
     }
@@ -115,7 +120,8 @@ public class TransportistaServiceImpl implements ITransportistaService {
     public void eliminar(long idTransportista) {
         Transportista transportista = this.getTransportistaPorId(idTransportista);
         if (transportista == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_transportista_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_transportista_no_existente"));
         }
         transportista.setEliminado(true);
         transportistaRepository.actualizar(transportista);

--- a/src/main/java/sic/service/impl/UsuarioServiceImpl.java
+++ b/src/main/java/sic/service/impl/UsuarioServiceImpl.java
@@ -30,7 +30,8 @@ public class UsuarioServiceImpl implements IUsuarioService {
     public Usuario getUsuarioPorId(Long idUsuario) {
         Usuario usuario = usuarioRepository.getUsuarioPorId(idUsuario);;
         if (usuario == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_usuario_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_usuario_no_existente"));
         }
         return usuario;
     }
@@ -114,7 +115,8 @@ public class UsuarioServiceImpl implements IUsuarioService {
     public void eliminar(long idUsuario) {
         Usuario usuario = this.getUsuarioPorId(idUsuario);
         if (usuario == null) {
-            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_usuario_no_existente"));
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes")
+                    .getString("mensaje_usuario_no_existente"));
         }
         this.validarOperacion(TipoDeOperacion.ELIMINACION, usuario);
         usuario.setEliminado(true);

--- a/src/main/java/sic/service/impl/UsuarioServiceImpl.java
+++ b/src/main/java/sic/service/impl/UsuarioServiceImpl.java
@@ -2,6 +2,7 @@ package sic.service.impl;
 
 import java.util.List;
 import java.util.ResourceBundle;
+import javax.persistence.EntityNotFoundException;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -27,7 +28,11 @@ public class UsuarioServiceImpl implements IUsuarioService {
 
     @Override
     public Usuario getUsuarioPorId(Long idUsuario) {
-        return usuarioRepository.getUsuarioPorId(idUsuario);
+        Usuario usuario = usuarioRepository.getUsuarioPorId(idUsuario);;
+        if (usuario == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_usuario_no_existente"));
+        }
+        return usuario;
     }
     
     @Override
@@ -108,6 +113,9 @@ public class UsuarioServiceImpl implements IUsuarioService {
     @Transactional
     public void eliminar(long idUsuario) {
         Usuario usuario = this.getUsuarioPorId(idUsuario);
+        if (usuario == null) {
+            throw new EntityNotFoundException(ResourceBundle.getBundle("Mensajes").getString("mensaje_usuario_no_existente"));
+        }
         this.validarOperacion(TipoDeOperacion.ELIMINACION, usuario);
         usuario.setEliminado(true);
         usuarioRepository.actualizar(usuario);

--- a/src/main/java/sic/util/Validator.java
+++ b/src/main/java/sic/util/Validator.java
@@ -80,7 +80,7 @@ public class Validator {
     }
     
     public static boolean tieneDuplicados(long[] array) {
-        Set<Long> set = new HashSet<Long>();
+        Set<Long> set = new HashSet<>();
         for (long i : array) {
             if (set.contains(i)) {
                 return true;

--- a/src/main/java/sic/util/Validator.java
+++ b/src/main/java/sic/util/Validator.java
@@ -2,6 +2,8 @@ package sic.util;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 public class Validator {
@@ -75,5 +77,16 @@ public class Validator {
         anterior.setTime(fechaAnterior);
         siguiente.setTime(fechaSiguiente);
         return siguiente.compareTo(anterior);
+    }
+    
+    public static boolean tieneDuplicados(long[] array) {
+        Set<Long> set = new HashSet<Long>();
+        for (long i : array) {
+            if (set.contains(i)) {
+                return true;
+            }
+            set.add(i);
+        }
+        return false;
     }
 }

--- a/src/main/resources/Mensajes.properties
+++ b/src/main/resources/Mensajes.properties
@@ -20,6 +20,10 @@ mensaje_cliente_vacio_empresa=La empresa se encuetra vacia.
 mensaje_cliente_duplicado_idFiscal=Ya existe un cliente con el ID fiscal ingresado.
 mensaje_cliente_duplicado_razonSocial=Ya existe un cliente con la razon social ingresada.
 mensaje_cliente_sin_predeterminado=No posee ning\u00fan Cliente Predeterminado con la empresa seleccionada.\n Debe establecer uno como Predeterminado o dar de alta uno nuevo\n para poder utilizar el Punto de Venta.
+mensaje_cliente_no_existente=El cliente solicitado no existe.
+
+#Configuracion Del Sistema
+mensaje_cds_no_existente= La configuracion de sistema solicitada no existe.
 
 #Producto
 mensaje_pregunta_eliminar_productos=\u00bfEsta seguro que desea eliminar los Productos seleccionados?
@@ -33,6 +37,7 @@ mensaje_sin_cliente=No existe ning\u00fan Cliente disponible. Debe tener al meno
 #Condicion IVA
 mensaje_condicionIVA_nombre_requerido=Ingrese un nombre de condici\u00f3n de IVA para poder continuar.
 mensaje_condicionIVA_nombre_duplicado=Ya existe una condicion de IVA con el nombre ingresado.
+mensaje_CondicionIVA_no_existente=No existe la condici\u00f3n de IVA.
 
 #Empresa
 mensaje_empresa_email_invalido=El correo electronico de la empresa, no es v\u00e1lido.
@@ -42,6 +47,7 @@ mensaje_empresa_vacio_condicionIVA=La condicion de IVA de la empresa se encuentr
 mensaje_empresa_vacio_localidad=La localidad de la empresa se encuetra vac\u00eda.
 mensaje_empresa_duplicado_nombre=Ya existe una empresa con el nombre ingresado.
 mensaje_empresa_duplicado_cuip=Ya existe una empresa con el CUIT/CUIL/CUIP ingresado.
+mensaje_empresa_no_existente=La empresa solicitada no existe.
 
 #Factura
 mensaje_factura_fechas_busqueda_invalidas=Las fechas ingresadas para la busqueda son invalidas.
@@ -65,15 +71,18 @@ mensaje_formaDePago_vacio_nombre=El nombre de la forma de pago se encuentra vaci
 mensaje_formaDePago_empresa_vacio=La empresa de la forma de pago se encuentra vac\u00eda.
 mensaje_formaDePago_duplicado_nombre=Ya existe una forma de pago con el nombre ingresado.
 mensaje_formaDePago_sin_predeterminada=No posee ninguna Forma de Pago Predeterminada con la empresa seleccionada.\n Debe establecer una como Predeterminada o dar de alta una nueva\n para poder utilizar el Punto de Venta.
+mensaje_formaDePago_no_existente=La Forma de Pago solicitada no existe.
 
 #Localidad
 mensaje_localidad_vacio_nombre=El nombre de la localidad se encuentra vacio.
 mensaje_localidad_provincia_vacio=La provincia de la localidad se encuentra vac\u00eda.
 mensaje_localidad_duplicado_nombre=Ya existe una localidad con el nombre ingresado.
+mensaje_localidad_no_existente=La localidad solicitada no existe.
 
 #Medida
 mensaje_medida_vacio_nombre=El nombre de la medida se encuentra vac\u00eda.
 mensaje_medida_duplicada_nombre=Ya existe una medida con el nombre ingresado.
+mensaje_medida_no_existente=La medida solicitada no existe.
 
 #Pago de factura 
 mensaje_pago_mayorQueCero_monto=El monto del pago debe ser mayor a 0.
@@ -88,6 +97,7 @@ mensaje_pago_inexistente_eliminado=El pago no existe o ya se encuentra eliminado
 #Pais
 mensaje_pais_vacio_nombre=El nombre del pais se encuentra vacio.
 mensaje_pais_duplicado_nombre=Ya existe un pais con el nombre ingresado.
+mensaja_pais_no_existente=El pais solicitado no existe.
 
 #Producto
 mensaje_producto_cantidad_negativa=La cantidad de productos no puede ser negativa.
@@ -106,6 +116,7 @@ mensaje_producto_vacio_empresa=La empresa del producto se encuentra vac\u00eda.
 mensaje_producto_duplicado_codigo=Ya existe un producto con el c\u00f3digo ingresado.
 mensaje_producto_duplicado_descripcion=Ya existe un producto con la descripci\u00f3n ingresada.
 mensaje_producto_sin_stock_suficiente=La cantidad solicitada del producto supera el stock disponible.
+mensaje_producto_no_existente=El producto solicitado no existe.
 
 #Proveedor
 mensaje_proveedor_email_invalido=El correo electronico del proveedor, no es v\u00e1lido.
@@ -116,15 +127,18 @@ mensaje_proveedor_empresa_vacia=La empresa del proveedor se encuentra vac\u00eda
 mensaje_proveedor_duplicado_codigo=Ya existe un proveedor con el c\u00f3digo ingresado.
 mensaje_proveedor_duplicado_idFiscal=Ya existe un proveedor con el ID fiscal ingresado.
 mensaje_proveedor_duplicado_razonSocial=Ya existe un proveedor con la razon social ingresada.
+mensaje_proveedor_no_existente=El proveedor solicitado no existe.
 
 #Provincia
 mensaje_provincia_vacio_nombre=El nombre de la provincia se encuentra vacio.
 mensaje_provincia_pais_vacio=El pais de la provincia se encuentra vacio.
 mensaje_provincia_duplicado_nombre=Ya existe una provincia con el nombre ingresado.
+mensaje_provincia_no_existente=La localidad solicitada no existe.
 
 #Rubro
 mensaje_rubro_nombre_vacio=El nombre del rubro se encuentra vacio.
 mensaje_rubro_nombre_duplicado=Ya existe un rubro con el nombre ingresado.
+mensaje_rubro_no_existente=El rubro solicitado no existe. 
 
 #Transportista
 mensaje_transportista_nombre_vacio=El nombre del transportista se encuentra vacio.
@@ -132,6 +146,7 @@ mensaje_transportista_localidad_vacia=La localidad del transportista se encuentr
 mensaje_transportista_empresa_vacia=La empresa del transportista se encuentra vac\u00eda.
 mensaje_transportista_duplicado_nombre=Ya existe un transportista con el nombre ingresado.
 mensaje_transportista_ninguno_cargado=No posee ning\u00fan Transportista cargado en la empresa seleccionada.\n Debe dar de alta al menos uno para poder utilizar el Punto de Venta.
+mensaje_transportista_no_existente=El transportista solicitado no existe.
 
 #Usuario
 mensaje_usuario_duplicado_nombre=Ya existe un usuario con el nombre ingresado.
@@ -139,6 +154,7 @@ mensaje_usuario_ultimoAdmin=No es posible modificar o eliminar este usuario,\npo
 mensaje_usuario_logInInvalido=Nombre de usuario o contrase\u00f1a incorrecta.
 mensaje_usuario_vacio_nombre=El nombre de usuario se encuentra vac\u00edo.
 mensaje_usuario_vacio_password=La contrase\u00f1a se encuentra vac\u00eda.
+mensaje_usuario_no_existente=El usuario solicitado no existe.
 
 #Pedido
 mensaje_pedido_fechas_busqueda_invalidas=Las fechas no son v\u00e1lidas.
@@ -148,9 +164,10 @@ mensaje_pedido_renglones_vacio=Los renglones del pedido se encuentran vac\u00edo
 mensaje_pedido_empresa_vacia=El pedido no contiene ninguna empresa.
 mensaje_pedido_error_al_buscar=Se produjo un error al realizar la busqueda.
 mensaje_pedido_duplicado=El n\u00famero de pedido ya existe.
-mensaje_pedido_no_existente=El n\u00famero de pedido no existe.
+mensaje_pedido_no_existente=El pedido solicitado no existe.
 mensaje_pedido_facturado=No se puede realizar esta operaci\u00f3n, el pedido se encuentra totalmente facturado.
 mensaje_pedido_procesado=No se puede realizar esta operaci\u00f3n, el pedido se encuentra parcialmente facturado.
+mensaja_estado_no_valido=El estado del pedido no corresponde con uno v\u00e1lido.
 
 #Caja
 mensaje_caja_fecha_vacia=La fecha se encuentra vac\u00eda.
@@ -158,12 +175,16 @@ mensaje_caja_empresa_vacia=La caja no contiene ninguna empresa.
 mensaje_caja_usuario_vacio=La caja no contiene ning\u00fan usuario.
 mensaje_caja_duplicada=El n\u00famero de caja ya existe.
 mensaje_caja_fechas_invalidas=Las fechas seleccionadas no son v\u00e1lidas.
+mensaje_caja_anterior_abierta=La caja anterior a\u00fan se encuentra abierta.
+mensaje_fecha_apertura_no_valida=La fecha de apertura de la caja no es v\u00e1lida.
+mensaje_caja_no_existente=La caja a eliminar no existe.
 
 #Gasto
 mensaje_gasto_fecha_vacia=La fecha se encuentra vac\u00eda.
 mensaje_gasto_empresa_vacia=El gasto no contiene ninguna empresa.
 mensaje_gasto_usuario_vacio=El gasto no contiene ning\u00fan usuario.
 mensaje_gasto_duplicada=El n\u00famero de gasto ya existe.
+mensaje_gasto_no_existente=El gasto solicitado no existe.
 
 #Reporte
 mensaje_error_reporte=Se produjo un error procesando el reporte.

--- a/src/main/resources/Mensajes.properties
+++ b/src/main/resources/Mensajes.properties
@@ -189,3 +189,6 @@ mensaje_gasto_no_existente=El gasto solicitado no existe.
 
 #Reporte
 mensaje_error_reporte=Se produjo un error procesando el reporte.
+
+#Ids Duplicados
+mensaje_ids_duplicados=No se permiten Ids duplicados.

--- a/src/main/resources/Mensajes.properties
+++ b/src/main/resources/Mensajes.properties
@@ -1,5 +1,5 @@
 #Version
-version=v1.9.2
+version=v2.0
 
 #Avisos
 mensaje_busqueda_sin_resultados=No se encontraron resultados para la busqueda.
@@ -191,4 +191,4 @@ mensaje_gasto_no_existente=El gasto solicitado no existe.
 mensaje_error_reporte=Se produjo un error procesando el reporte.
 
 #Ids Duplicados
-mensaje_ids_duplicados=No se permiten Ids duplicados.
+mensaje_ids_duplicados=No se permiten ids duplicados.

--- a/src/main/resources/Mensajes.properties
+++ b/src/main/resources/Mensajes.properties
@@ -72,6 +72,7 @@ mensaje_formaDePago_empresa_vacio=La empresa de la forma de pago se encuentra va
 mensaje_formaDePago_duplicado_nombre=Ya existe una forma de pago con el nombre ingresado.
 mensaje_formaDePago_sin_predeterminada=No posee ninguna Forma de Pago Predeterminada con la empresa seleccionada.\n Debe establecer una como Predeterminada o dar de alta una nueva\n para poder utilizar el Punto de Venta.
 mensaje_formaDePago_no_existente=La Forma de Pago solicitada no existe.
+mensaje_formaDePago_predeterminada_existente=Ya existe una forma de pago predeterminada.
 
 #Localidad
 mensaje_localidad_vacio_nombre=El nombre de la localidad se encuentra vacio.

--- a/src/main/resources/Mensajes.properties
+++ b/src/main/resources/Mensajes.properties
@@ -178,7 +178,7 @@ mensaje_caja_duplicada=El n\u00famero de caja ya existe.
 mensaje_caja_fechas_invalidas=Las fechas seleccionadas no son v\u00e1lidas.
 mensaje_caja_anterior_abierta=La caja anterior a\u00fan se encuentra abierta.
 mensaje_fecha_apertura_no_valida=La fecha de apertura de la caja no es v\u00e1lida.
-mensaje_caja_no_existente=La caja a eliminar no existe.
+mensaje_caja_no_existente=La caja no existe.
 
 #Gasto
 mensaje_gasto_fecha_vacia=La fecha se encuentra vac\u00eda.

--- a/src/test/java/sic/service/impl/FacturaServiceImplTest.java
+++ b/src/test/java/sic/service/impl/FacturaServiceImplTest.java
@@ -214,7 +214,9 @@ public class FacturaServiceImplTest {
         factura.setTransportista(Transportista.builder().nombre("demonte").build());
         factura.setEmpresa(Empresa.builder().nombre("CocaCola").build());
         factura.setCliente(Cliente.builder().nombreFantasia("Enrrique Iglesias").build());
-        factura.setUsuario(Usuario.builder().nombre("Marian Jhons  help").build());
+        Usuario usuario = new Usuario();
+        usuario.setNombre("Marian Jhons  help");
+        factura.setUsuario(usuario);
         factura.setTipoFactura('A');
         int[] indices = {0, 1};
         int cantidadDeFacturasEsperadas = 2;


### PR DESCRIPTION
Verifica que el estado del pedido a modificar o alta se encuentren en la enum.
Set clientes predeterminado recibe solo un id
Corta el json para que no devuelva el pass y permisosAdmin de Usuario
En los delete, lanza un msj si no se eucuentra la entity por ese id, usa la nueva exception EntityNotFoundException.
Permite abrir solo una caja por día.
Se pueden dar de alta solo una forma de pago predeterminada.
Se pueden dar de alta solo un cliente predeterminado.
El código en producto y proveedor puede no estar declarado en el Json.
Los códigos no admiten duplicados.
En las criterias que se busca por país, provincia y localidad, se considera la posibilidad de un id distinto de null, que no exista realmente, y lanza un EntityNotFoundException.

